### PR TITLE
hacked in basic yaw wrapping

### DIFF
--- a/mav_disturbance_observer/src/KF_disturbance_observer.cpp
+++ b/mav_disturbance_observer/src/KF_disturbance_observer.cpp
@@ -404,6 +404,14 @@ bool KFDisturbanceObserver::updateEstimator()
 
   K_ = state_covariance_ * H_.transpose() * tmp.inverse();
 
+  //account for yaw wrapping
+  while(std::abs(measurements_(8) - predicted_state_(8)) > std::abs(measurements_(8) - predicted_state_(8) + 2.0*M_PI)){
+    measurements_(8) += 2.0*M_PI;
+  }
+  while(std::abs(measurements_(8) - predicted_state_(8)) > std::abs(measurements_(8) - predicted_state_(8) - 2.0*M_PI)){
+    measurements_(8) -= 2.0*M_PI;
+  }
+
   //Update with measurements
   state_ = predicted_state_ + K_ * (measurements_ - H_ * state_);
 


### PR DESCRIPTION
Actually Zac on Flybook,
![img_20180704_114007](https://user-images.githubusercontent.com/5616392/42273609-ed8ba5c0-7f89-11e8-8160-9efe902dbdbe.jpg)

The kalman filter does not take into account the fact that yaw can wrap, this causes a massive jump in the z moment. This is an ugly hack for now that I will fix properly when I get back to lab