### PR TITLE
cleaner yaw wrap

### DIFF
--- a/mav_disturbance_observer/src/KF_disturbance_observer.cpp
+++ b/mav_disturbance_observer/src/KF_disturbance_observer.cpp
@@ -405,12 +405,7 @@ bool KFDisturbanceObserver::updateEstimator()
   K_ = state_covariance_ * H_.transpose() * tmp.inverse();
 
   //account for yaw wrapping
-  while(std::abs(measurements_(8) - predicted_state_(8)) > std::abs(measurements_(8) - predicted_state_(8) + 2.0*M_PI)){
-    measurements_(8) += 2.0*M_PI;
-  }
-  while(std::abs(measurements_(8) - predicted_state_(8)) > std::abs(measurements_(8) - predicted_state_(8) - 2.0*M_PI)){
-    measurements_(8) -= 2.0*M_PI;
-  }
+  measurements_(8) = fmod(measurements_(8) - state_(8) + M_PI, (2.0 * M_PI)) - M_PI + state_(8);
 
   //Update with measurements
   state_ = predicted_state_ + K_ * (measurements_ - H_ * state_);


### PR DESCRIPTION
The fix in #19 was an ugly hack with two issues. It had an unneeded while loop and more importantly if the prediction became off by an entire revolution the system would become stuck in this state.

This pr should fix both issues, I will test on a platform later today